### PR TITLE
Fix libvoxel_grid.so conflict

### DIFF
--- a/planning_ros_utils/CMakeLists.txt
+++ b/planning_ros_utils/CMakeLists.txt
@@ -40,9 +40,9 @@ else(NOT VTK_FOUND)
   cs_add_executable(mesh_sampling src/mapping_utils/mesh_sampling.cpp)
 endif(NOT VTK_FOUND)
 
-cs_add_library(voxel_grid src/mapping_utils/voxel_grid.cpp)
+cs_add_library(mpl_voxel_grid src/mapping_utils/voxel_grid.cpp)
 cs_add_executable(cloud_to_map src/mapping_utils/cloud_to_map.cpp)
-target_link_libraries(cloud_to_map voxel_grid)
+target_link_libraries(cloud_to_map mpl_voxel_grid)
 
 cs_add_executable(image_to_map src/mapping_utils/image_to_map.cpp)
 target_link_libraries(image_to_map


### PR DESCRIPTION
After following the installation instructions, I was able to run the provided examples just fine. However, I discovered that my Turtlebot-based navigation configurations no longer functioned properly:
```
.../system_catkin_ws/rinstall/lib/move_base/move_base: symbol lookup error: 
.../system_catkin_ws/rinstall/lib/liblayers.so: undefined symbol: _ZN10voxel_grid9VoxelGridC1Ejjj
```
Long story short, the source of the problem was that the `libvoxel_grid.so` library created by `planning_ros_utils/CMakeLists.txt` had the same name as the library produced by the [voxel_grid](https://github.com/ros-planning/navigation/tree/kinetic-devel/voxel_grid) package in the ROS Navigation Stack.

Changing the name of the library to something unique resolves the issue.